### PR TITLE
Update model catalog to current Go plan roster

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,27 +60,38 @@ COMMANDCODE_API_KEY=your-key opencode
 
 | Model ID | Name | Tier | Reasoning | Context |
 |---|---|---|---|---|
-| `claude-haiku-4-5-20251001`                | Claude Haiku 4.5            | premium      | no  | 200K   |
-| `claude-opus-4-7`                          | Claude Opus 4.7             | premium      | yes | 1M     |
-| `claude-sonnet-4-6`                        | Claude Sonnet 4.6           | premium      | yes | 1M     |
-| `gpt-5.3-codex`                            | GPT-5.3 Codex               | premium      | yes | 400K   |
-| `gpt-5.4`                                  | GPT-5.4                     | premium      | yes | 400K   |
-| `gpt-5.4-mini`                             | GPT-5.4 Mini                | premium      | yes | 400K   |
-| `gpt-5.5`                                  | GPT-5.5                     | premium      | yes | 256K   |
-| `deepseek/deepseek-v4-flash`               | DeepSeek V4 Flash           | open-source  | yes | 1M     |
-| `deepseek/deepseek-v4-pro`                 | DeepSeek V4 Pro             | open-source  | yes | 1M     |
-| `google/gemini-3.1-flash-lite`             | Gemini 3.1 Flash Lite       | open-source  | yes | 1M     |
-| `google/gemini-3.5-flash`                  | Gemini 3.5 Flash            | open-source  | yes | 1M     |
-| `zai-org/GLM-5`                            | GLM-5                       | open-source  | no  | 200K   |
-| `zai-org/GLM-5.1`                          | GLM-5.1                     | open-source  | no  | 200K   |
-| `moonshotai/Kimi-K2.5`                     | Kimi K2.5                   | open-source  | no  | 256K   |
+| `poolside/laguna-s-2.1-free`               | Laguna S 2.1                | open-source  | no  | 256K   |
+| `tencent/hy3-paid`                         | Tencent Hy3                 | open-source  | yes | 262K   |
+| `moonshotai/Kimi-K3`                       | Kimi K3                     | open-source  | yes | 1M     |
+| `moonshotai/Kimi-K2.7-Code`                | Kimi K2.7 Code              | open-source  | yes | 256K   |
+| `moonshotai/Kimi-K2.7-Code-Highspeed`      | Kimi K2.7 Code HighSpeed    | open-source  | yes | 262K   |
 | `moonshotai/Kimi-K2.6`                     | Kimi K2.6                   | open-source  | no  | 256K   |
-| `MiniMaxAI/MiniMax-M2.5`                   | MiniMax M2.5                | open-source  | no  | 200K   |
+| `moonshotai/Kimi-K2.5`                     | Kimi K2.5                   | open-source  | no  | 256K   |
+| `zai-org/GLM-5.2`                          | GLM-5.2                     | open-source  | yes | 1M     |
+| `zai-org/GLM-5.2-Fast`                     | GLM-5.2 Fast                | open-source  | yes | 1M     |
+| `zai-org/GLM-5.1`                          | GLM-5.1                     | open-source  | no  | 1M     |
+| `zai-org/GLM-5`                            | GLM-5                       | open-source  | no  | 200K   |
+| `MiniMaxAI/MiniMax-M3`                     | MiniMax M3                  | open-source  | yes | 1M     |
 | `MiniMaxAI/MiniMax-M2.7`                   | MiniMax M2.7                | open-source  | no  | 1M     |
+| `MiniMaxAI/MiniMax-M2.5`                   | MiniMax M2.5                | open-source  | no  | 200K   |
+| `deepseek/deepseek-v4-pro`                 | DeepSeek V4 Pro             | open-source  | yes | 1M     |
+| `deepseek/deepseek-v4-flash`               | DeepSeek V4 Flash           | open-source  | yes | 1M     |
+| `Qwen/Qwen3.8-Max`                         | Qwen 3.8 Max                | open-source  | yes | 1M     |
 | `Qwen/Qwen3.6-Max-Preview`                 | Qwen 3.6 Max Preview        | open-source  | yes | 1M     |
 | `Qwen/Qwen3.6-Plus`                        | Qwen 3.6 Plus               | open-source  | yes | 1M     |
 | `Qwen/Qwen3.7-Max`                         | Qwen 3.7 Max                | open-source  | yes | 1M     |
+| `Qwen/Qwen3.7-Plus`                        | Qwen 3.7 Plus               | open-source  | yes | 1M     |
+| `Qwen/Qwen3.7-Flash`                       | Qwen 3.7 Flash              | open-source  | yes | 1M     |
+| `stepfun/Step-3.7-Flash`                   | Step 3.7 Flash              | open-source  | yes | 256K   |
 | `stepfun/Step-3.5-Flash`                   | Step 3.5 Flash              | open-source  | yes | 1M     |
+| `xiaomi/mimo-v2.5-pro`                     | MiMo V2.5 Pro               | open-source  | yes | 1M     |
+| `xiaomi/mimo-v2.5`                         | MiMo V2.5                   | open-source  | no  | 1M     |
+| `nvidia/nemotron-3-ultra-550b-a55b`        | Nemotron 3 Ultra            | open-source  | yes | 1M     |
+| `gpt-5.6-luna`                             | GPT-5.6 Luna                | premium      | yes | 1M     |
+| `meta/muse-spark-1.2-contributor`          | Muse Spark 1.2 Contributor  | premium      | yes | 1M     |
+| `xai/grok-4.5`                             | Grok 4.5                    | premium      | yes | 500K   |
+| `thinkingmachines/inkling`                 | Inkling                     | open-source  | yes | 256K   |
+| `thinkingmachines/inkling-small`           | Inkling Small               | open-source  | yes | 1M     |
 
 Full model list is maintained in [`models.json`](./models.json). Run `bun run sync` to refresh from the latest Command Code CLI release on npm.
 

--- a/models.json
+++ b/models.json
@@ -1,226 +1,81 @@
 [
   {
-    "id": "claude-haiku-4-5-20251001",
-    "name": "Claude Haiku 4.5",
-    "tier": "premium",
+    "id": "poolside/laguna-s-2.1-free",
+    "name": "Laguna S 2.1",
+    "tier": "open-source",
     "reasoning": false,
     "tool_call": true,
     "cost": {
-      "input": 1,
-      "output": 5,
-      "cache_read": 0.1,
-      "cache_write": 1.25
-    },
-    "limit": {
-      "context": 200000,
-      "output": 8192
-    }
-  },
-  {
-    "id": "claude-opus-4-7",
-    "name": "Claude Opus 4.7",
-    "tier": "premium",
-    "reasoning": true,
-    "tool_call": true,
-    "cost": {
-      "input": 5,
-      "output": 25,
-      "cache_read": 0.5,
-      "cache_write": 6.25
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 32000
-    }
-  },
-  {
-    "id": "claude-sonnet-4-6",
-    "name": "Claude Sonnet 4.6",
-    "tier": "premium",
-    "reasoning": true,
-    "tool_call": true,
-    "cost": {
-      "input": 3,
-      "output": 15,
-      "cache_read": 0.3,
-      "cache_write": 3.75
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 16000
-    }
-  },
-  {
-    "id": "gpt-5.3-codex",
-    "name": "GPT-5.3 Codex",
-    "tier": "premium",
-    "reasoning": true,
-    "tool_call": true,
-    "cost": {
-      "input": 2,
-      "output": 8,
-      "cache_read": 0.5
-    },
-    "limit": {
-      "context": 400000,
-      "output": 128000
-    }
-  },
-  {
-    "id": "gpt-5.4",
-    "name": "GPT-5.4",
-    "tier": "premium",
-    "reasoning": true,
-    "tool_call": true,
-    "cost": {
-      "input": 2.5,
-      "output": 15,
-      "cache_read": 0.25
-    },
-    "limit": {
-      "context": 400000,
-      "output": 128000
-    }
-  },
-  {
-    "id": "gpt-5.4-mini",
-    "name": "GPT-5.4 Mini",
-    "tier": "premium",
-    "reasoning": true,
-    "tool_call": true,
-    "cost": {
-      "input": 0.75,
-      "output": 4.5,
-      "cache_read": 0.075
-    },
-    "limit": {
-      "context": 400000,
-      "output": 128000
-    }
-  },
-  {
-    "id": "gpt-5.5",
-    "name": "GPT-5.5",
-    "tier": "premium",
-    "reasoning": true,
-    "tool_call": true,
-    "cost": {
-      "input": 5,
-      "output": 30,
-      "cache_read": 0.5
+      "input": 0,
+      "output": 0,
+      "cache_read": 0
     },
     "limit": {
       "context": 256000,
-      "output": 128000
+      "output": 131072
     }
   },
   {
-    "id": "deepseek/deepseek-v4-flash",
-    "name": "DeepSeek V4 Flash",
+    "id": "tencent/hy3-paid",
+    "name": "Tencent Hy3",
     "tier": "open-source",
     "reasoning": true,
     "tool_call": true,
     "cost": {
       "input": 0.14,
-      "output": 0.28,
-      "cache_read": 0.01
+      "output": 0.58,
+      "cache_read": 0.035
     },
     "limit": {
-      "context": 1000000,
-      "output": 384000
+      "context": 262000,
+      "output": 131072
     }
   },
   {
-    "id": "deepseek/deepseek-v4-pro",
-    "name": "DeepSeek V4 Pro",
+    "id": "moonshotai/Kimi-K3",
+    "name": "Kimi K3",
     "tier": "open-source",
     "reasoning": true,
     "tool_call": true,
     "cost": {
-      "input": 0.435,
-      "output": 0.87,
-      "cache_read": 0.003625
+      "input": 3,
+      "output": 15,
+      "cache_read": 0.3
     },
     "limit": {
       "context": 1000000,
-      "output": 384000
+      "output": 131072
     }
   },
   {
-    "id": "google/gemini-3.1-flash-lite",
-    "name": "Gemini 3.1 Flash Lite",
+    "id": "moonshotai/Kimi-K2.7-Code",
+    "name": "Kimi K2.7 Code",
     "tier": "open-source",
     "reasoning": true,
-    "tool_call": true,
-    "cost": {
-      "input": 0.25,
-      "output": 1.5,
-      "cache_read": 0.03
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 65536
-    }
-  },
-  {
-    "id": "google/gemini-3.5-flash",
-    "name": "Gemini 3.5 Flash",
-    "tier": "open-source",
-    "reasoning": true,
-    "tool_call": true,
-    "cost": {
-      "input": 1.5,
-      "output": 9,
-      "cache_read": 0.15
-    },
-    "limit": {
-      "context": 1000000,
-      "output": 65536
-    }
-  },
-  {
-    "id": "zai-org/GLM-5",
-    "name": "GLM-5",
-    "tier": "open-source",
-    "reasoning": false,
     "tool_call": true,
     "cost": {
       "input": 0.95,
-      "output": 3.15
-    },
-    "limit": {
-      "context": 200000,
-      "output": 131072
-    }
-  },
-  {
-    "id": "zai-org/GLM-5.1",
-    "name": "GLM-5.1",
-    "tier": "open-source",
-    "reasoning": false,
-    "tool_call": true,
-    "cost": {
-      "input": 1.4,
-      "output": 4.4,
-      "cache_read": 0.26
-    },
-    "limit": {
-      "context": 200000,
-      "output": 131072
-    }
-  },
-  {
-    "id": "moonshotai/Kimi-K2.5",
-    "name": "Kimi K2.5",
-    "tier": "open-source",
-    "reasoning": false,
-    "tool_call": true,
-    "cost": {
-      "input": 0.6,
-      "output": 3
+      "output": 4,
+      "cache_read": 0.19
     },
     "limit": {
       "context": 256000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "moonshotai/Kimi-K2.7-Code-Highspeed",
+    "name": "Kimi K2.7 Code HighSpeed",
+    "tier": "open-source",
+    "reasoning": true,
+    "tool_call": true,
+    "cost": {
+      "input": 1.9,
+      "output": 8,
+      "cache_read": 0.38
+    },
+    "limit": {
+      "context": 262000,
       "output": 131072
     }
   },
@@ -241,17 +96,98 @@
     }
   },
   {
-    "id": "MiniMaxAI/MiniMax-M2.5",
-    "name": "MiniMax M2.5",
+    "id": "moonshotai/Kimi-K2.5",
+    "name": "Kimi K2.5",
     "tier": "open-source",
     "reasoning": false,
     "tool_call": true,
     "cost": {
-      "input": 0.5,
-      "output": 2
+      "input": 0.6,
+      "output": 3,
+      "cache_read": 0.1
+    },
+    "limit": {
+      "context": 256000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "zai-org/GLM-5.2",
+    "name": "GLM-5.2",
+    "tier": "open-source",
+    "reasoning": true,
+    "tool_call": true,
+    "cost": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "zai-org/GLM-5.2-Fast",
+    "name": "GLM-5.2 Fast",
+    "tier": "open-source",
+    "reasoning": true,
+    "tool_call": true,
+    "cost": {
+      "input": 3,
+      "output": 10.25,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "zai-org/GLM-5.1",
+    "name": "GLM-5.1",
+    "tier": "open-source",
+    "reasoning": false,
+    "tool_call": true,
+    "cost": {
+      "input": 1.4,
+      "output": 4.4,
+      "cache_read": 0.26
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "zai-org/GLM-5",
+    "name": "GLM-5",
+    "tier": "open-source",
+    "reasoning": false,
+    "tool_call": true,
+    "cost": {
+      "input": 1,
+      "output": 3.2,
+      "cache_read": 0.2
     },
     "limit": {
       "context": 200000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "MiniMaxAI/MiniMax-M3",
+    "name": "MiniMax M3",
+    "tier": "open-source",
+    "reasoning": true,
+    "tool_call": true,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.06
+    },
+    "limit": {
+      "context": 1000000,
       "output": 131072
     }
   },
@@ -265,6 +201,71 @@
       "input": 0.3,
       "output": 1.2,
       "cache_read": 0.06
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "MiniMaxAI/MiniMax-M2.5",
+    "name": "MiniMax M2.5",
+    "tier": "open-source",
+    "reasoning": false,
+    "tool_call": true,
+    "cost": {
+      "input": 0.3,
+      "output": 1.2,
+      "cache_read": 0.03
+    },
+    "limit": {
+      "context": 200000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "deepseek/deepseek-v4-pro",
+    "name": "DeepSeek V4 Pro",
+    "tier": "open-source",
+    "reasoning": true,
+    "tool_call": true,
+    "cost": {
+      "input": 0.435,
+      "output": 0.87,
+      "cache_read": 0.003625
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "deepseek/deepseek-v4-flash",
+    "name": "DeepSeek V4 Flash",
+    "tier": "open-source",
+    "reasoning": true,
+    "tool_call": true,
+    "cost": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.0028
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    }
+  },
+  {
+    "id": "Qwen/Qwen3.8-Max",
+    "name": "Qwen 3.8 Max",
+    "tier": "open-source",
+    "reasoning": true,
+    "tool_call": true,
+    "cost": {
+      "input": 2,
+      "output": 6,
+      "cache_read": 0.25,
+      "cache_write": 2.5
     },
     "limit": {
       "context": 1000000,
@@ -311,13 +312,63 @@
     "reasoning": true,
     "tool_call": true,
     "cost": {
-      "input": 1.25,
-      "output": 3.75,
-      "cache_read": 0.25,
-      "cache_write": 1.56
+      "input": 2.5,
+      "output": 7.5,
+      "cache_read": 0.5,
+      "cache_write": 3.13
     },
     "limit": {
       "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "Qwen/Qwen3.7-Plus",
+    "name": "Qwen 3.7 Plus",
+    "tier": "open-source",
+    "reasoning": true,
+    "tool_call": true,
+    "cost": {
+      "input": 0.4,
+      "output": 1.6,
+      "cache_read": 0.08,
+      "cache_write": 0.5
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "Qwen/Qwen3.7-Flash",
+    "name": "Qwen 3.7 Flash",
+    "tier": "open-source",
+    "reasoning": true,
+    "tool_call": true,
+    "cost": {
+      "input": 0.03,
+      "output": 0.13,
+      "cache_read": 0.006,
+      "cache_write": 0.038
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "stepfun/Step-3.7-Flash",
+    "name": "Step 3.7 Flash",
+    "tier": "open-source",
+    "reasoning": true,
+    "tool_call": true,
+    "cost": {
+      "input": 0.2,
+      "output": 1.15,
+      "cache_read": 0.04
+    },
+    "limit": {
+      "context": 256000,
       "output": 131072
     }
   },
@@ -331,6 +382,135 @@
       "input": 0.1,
       "output": 0.3,
       "cache_read": 0.02
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "xiaomi/mimo-v2.5-pro",
+    "name": "MiMo V2.5 Pro",
+    "tier": "open-source",
+    "reasoning": true,
+    "tool_call": true,
+    "cost": {
+      "input": 0.435,
+      "output": 0.87,
+      "cache_read": 0.0036
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "xiaomi/mimo-v2.5",
+    "name": "MiMo V2.5",
+    "tier": "open-source",
+    "reasoning": false,
+    "tool_call": true,
+    "cost": {
+      "input": 0.14,
+      "output": 0.28,
+      "cache_read": 0.0028
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "nvidia/nemotron-3-ultra-550b-a55b",
+    "name": "Nemotron 3 Ultra",
+    "tier": "open-source",
+    "reasoning": true,
+    "tool_call": true,
+    "cost": {
+      "input": 0.6,
+      "output": 2.4,
+      "cache_read": 0.12
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "gpt-5.6-luna",
+    "name": "GPT-5.6 Luna",
+    "tier": "premium",
+    "reasoning": true,
+    "tool_call": true,
+    "cost": {
+      "input": 0.1,
+      "output": 0.6,
+      "cache_read": 0.01,
+      "cache_write": 0.125
+    },
+    "limit": {
+      "context": 1100000,
+      "output": 128000
+    }
+  },
+  {
+    "id": "meta/muse-spark-1.2-contributor",
+    "name": "Muse Spark 1.2 Contributor",
+    "tier": "premium",
+    "reasoning": true,
+    "tool_call": true,
+    "cost": {
+      "input": 0.1,
+      "output": 0.2,
+      "cache_read": 0.002
+    },
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "xai/grok-4.5",
+    "name": "Grok 4.5",
+    "tier": "premium",
+    "reasoning": true,
+    "tool_call": true,
+    "cost": {
+      "input": 2,
+      "output": 6,
+      "cache_read": 0.5
+    },
+    "limit": {
+      "context": 500000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "thinkingmachines/inkling",
+    "name": "Inkling",
+    "tier": "open-source",
+    "reasoning": true,
+    "tool_call": true,
+    "cost": {
+      "input": 1,
+      "output": 4.05,
+      "cache_read": 0.17
+    },
+    "limit": {
+      "context": 256000,
+      "output": 131072
+    }
+  },
+  {
+    "id": "thinkingmachines/inkling-small",
+    "name": "Inkling Small",
+    "tier": "open-source",
+    "reasoning": true,
+    "tool_call": true,
+    "cost": {
+      "input": 0.5,
+      "output": 1.2,
+      "cache_read": 0.1
     },
     "limit": {
       "context": 1000000,


### PR DESCRIPTION
## Summary

Rebuilds `models.json` from the official **Command Code Go plan** listing ([commandcode.ai/docs/plans/go](https://commandcode.ai/docs/plans/go)) and regenerates the README model table.

The catalog now reflects the **32 models** available on the $1/month Go plan, with exact slugs from the CLI model registry ([commandcode.ai/docs/reference/cli/models](https://commandcode.ai/docs/reference/cli/models)).

## What changed

**New models added**
- `gpt-5.6-luna` — GPT-5.6 Luna (included on Go)
- `xai/grok-4.5` — Grok 4.5 (included on Go)
- `meta/muse-spark-1.2-contributor` — Muse Spark 1.2 Contributor (included on Go)
- `Qwen/Qwen3.8-Max`, `Qwen/Qwen3.7-Plus`, `Qwen/Qwen3.7-Flash`
- `moonshotai/Kimi-K3`, `Kimi-K2.7-Code`, `Kimi-K2.7-Code-Highspeed`
- `zai-org/GLM-5.2`, `GLM-5.2-Fast`
- `MiniMaxAI/MiniMax-M3`
- `stepfun/Step-3.7-Flash`
- `tencent/hy3-paid`
- `nvidia/nemotron-3-ultra-550b-a55b`
- `xiaomi/mimo-v2.5`, `xiaomi/mimo-v2.5-pro`
- `thinkingmachines/inkling`, `inkling-small`
- `poolside/laguna-s-2.1-free` (free while capacity lasts)

**Removed** premium models not on the Go plan (Claude, Gemini, GPT-5.3/5.4/5.5) — these would fail on a Go-only account.

**Refreshed** per-token rates (`input`/`output`/`cache_read`/`cache_write`) to the current Go-plan pricing, including active discounts (e.g. DeepSeek V4 Pro at $0.435 in / $0.87 out, MiniMax M3 at half price).

## Notes
- Schema unchanged — same fields the plugin already reads in `plugin.ts`.
- Config keys derived by `toConfigKey()` stay unique (verified no collisions after the slug rename of Kimi K3's `ai` usage).
- Unit tests: 70 pass / 3 fail — the 3 failures are **pre-existing** on `main` (verified by stashing the change and re-running), unrelated to this update.